### PR TITLE
Fix default flags for DashScope

### DIFF
--- a/src/frontend/app/api/lib/dashscope.ts
+++ b/src/frontend/app/api/lib/dashscope.ts
@@ -65,8 +65,8 @@ export class DashScopeAPI {
       },
       parameters: {
         stream: request.stream || false,
-        incremental_output: request.incremental_output || false,
-        has_thoughts: request.has_thoughts || true,
+        incremental_output: request.incremental_output ?? false,
+        has_thoughts: request.has_thoughts ?? true,
         enable_system_time: request.enable_system_time !== false,
         ...(request.rag_options && { rag_options: request.rag_options }),
       },
@@ -100,8 +100,8 @@ export class DashScopeAPI {
       },
       parameters: {
         stream: true,
-        incremental_output: request.incremental_output || true,
-        has_thoughts: request.has_thoughts || true,
+        incremental_output: request.incremental_output ?? false,
+        has_thoughts: request.has_thoughts ?? true,
         enable_system_time: request.enable_system_time !== false,
         ...(request.rag_options && { rag_options: request.rag_options }),
       },


### PR DESCRIPTION
## Summary
- use nullish coalescing for `incremental_output` and `has_thoughts` options

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe2210f6c832e87073a115fbb1207