### PR TITLE
Improve test-api.js stream validation

### DIFF
--- a/test-api.js
+++ b/test-api.js
@@ -15,9 +15,15 @@ async function testStreamAPI() {
     }),
   });
 
+  if (!response.ok) {
+    console.error(`Request failed with status ${response.status} ${response.statusText}`);
+    process.exit(1);
+  }
+
   const reader = response.body;
   const decoder = new TextDecoder();
   let buffer = '';
+  let hasDataChunk = false;
   
   for await (const chunk of reader) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -29,8 +35,14 @@ async function testStreamAPI() {
       if (line.startsWith('data: ')) {
         const data = line.slice(6);
         if (data === '[DONE]') {
+          if (!hasDataChunk) {
+            console.error('No data chunks received before [DONE]');
+            process.exit(1);
+          }
           console.log('=== 流结束 ===');
           return;
+        } else {
+          hasDataChunk = true;
         }
         
         try {
@@ -44,4 +56,4 @@ async function testStreamAPI() {
   }
 }
 
-testStreamAPI().catch(console.error); 
+testStreamAPI().catch(console.error);


### PR DESCRIPTION
## Summary
- check `response.ok` before reading the stream
- exit with an error if the stream request fails
- track whether any data chunks arrived before `[DONE]`
- assert at least one chunk was received

## Testing
- `node --check test-api.js`

------
https://chatgpt.com/codex/tasks/task_e_683fe232333c832e9300e08f07dcc677